### PR TITLE
Make GNNWrapper forward call to backbone compatible with **kwargs

### DIFF
--- a/topobenchmark/nn/wrappers/graph/gnn_wrapper.py
+++ b/topobenchmark/nn/wrappers/graph/gnn_wrapper.py
@@ -27,7 +27,7 @@ class GNNWrapper(AbstractWrapper):
         x_0 = self.backbone(
             batch.x_0,
             batch.edge_index,
-            batch.get("edge_weight", None),
+            edge_weight=batch.get("edge_weight", None),
         )
 
         model_out = {"labels": batch.y, "batch_0": batch.batch_0}


### PR DESCRIPTION
## Description
Quick fix to enable **kwargs in gnn wrapper backbone forward calls.

## Issue

The forward call in GNNWrapper changed to include three arguments -- x_0, edge_index and edge_weight. It used to be just the first two. To ensure future compatibility, I changed the third one to use a keyword to be compatible with **kwargs. Otherwise all forward backbone functions will need to explicitly accept edge_weight, even if they don't need it.
